### PR TITLE
Add latest udd version for Deno 'v' prefix fix

### DIFF
--- a/install-deno.sh
+++ b/install-deno.sh
@@ -6,7 +6,7 @@ echo "Install the latest version of Deno into $SANDBOX_CONF_HOME/bin"
 curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=$SANDBOX_CONF_HOME sh
 
 echo "Install 'Update Deno Dependencies' (UDD) utility"
-deno install -A -f -n udd https://deno.land/x/udd/main.ts
+deno install -A -f -n udd https://deno.land/x/udd@0.4.0/main.ts
 
 echo "Install Deno-based 'Keep a Changelog' (changelog) utility"
 deno install --allow-read --allow-write --unstable --name changelog -f https://raw.githubusercontent.com/oscarotero/keep-a-changelog/deno/bin.js


### PR DESCRIPTION
Added udd for the version that fixes the Deno 'v' prefix issue faced. As per [this](https://github.com/hayd/deno-udd/pull/25) discussion. 